### PR TITLE
Fix #1: add container-conf, add geant4

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -3,6 +3,5 @@ build_image_base=${sirepo_devbox_base:-radiasoft/sirepo-ci}
 build_is_public=1
 
 build_as_root() {
-    umask 022
     build_yum install rscode-geant4
 }

--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+build_image_base=${sirepo_devbox_base:-radiasoft/sirepo-ci}
+build_is_public=1
+
+build_as_root() {
+    umask 022
+    build_yum install rscode-geant4
+}


### PR DESCRIPTION
@robnagler this changes the build process for devbox by not installing the latest deps from [container-sirepo-ci](https://github.com/radiasoft/container-sirepo-ci/blob/68289cbd81f2ddd213a764e778c6db09deb59ea3/container-conf/build.sh). Instead the image is based on sirepo-ci so that image would have to be re-built to get the latest deps. We rarely build sirepo-devbox as it is currently so I don't think it will cause any problems with "old" dependencies but I wanted to call it out. 