### PR TITLE
Fix radiasoft/download#489: strip ABI section from qt5

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -4,4 +4,8 @@ build_is_public=1
 
 build_as_root() {
     build_yum install openssh-server rscode-geant4
+    # QT5 expects kernel >= 3.15. Centos7 supports 3.10. This removes
+    # the kernel check when loading the lib. This could result in
+    # errors when using QT but so far we haven't experienced any.
+    strip --remove-section=.note.ABI-tag /usr/lib64/libQt5Core.so
 }


### PR DESCRIPTION
libQt5Core.so only works on kernels > 3.15 (renameat2 syscall needs to be present). Doing this strip disables the check for ABI compatibility. This could result in problems when trying to make that call but in testing we didn't see any issues. See https://askubuntu.com/a/1163268 for more explanation.