### PR TITLE
Revert "Revert "Fix #7: Set base image to be radiasoft/beamsim-jupyter again""

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
-build_image_base=${sirepo_devbox_base:-radiasoft/sirepo-ci}
 build_is_public=1
+build_image_base=${sirepo_devbox_base:-radiasoft/beamsim-jupyter}
 
 build_as_root() {
+    install_repo_eval container-sirepo-base root
     build_yum install openssh-server rscode-geant4
     # QT5 expects kernel >= 3.15. Centos7 supports 3.10. This removes
     # the kernel check when loading the lib. This could result in
     # errors when using QT but so far we haven't experienced any.
     strip --remove-section=.note.ABI-tag /usr/lib64/libQt5Core.so
+}
+
+build_as_run_user() {
+    install_repo_eval container-sirepo-base
+    install_url radiasoft/sirepo
+    #POSIT: This relies on the fact that individual package names don't have spaces or special chars
+    npm install -g \
+        $(install_download package.json | jq -r '.devDependencies | to_entries | map("\(.key)@\(.value)") | .[]')
 }

--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -13,8 +13,4 @@ build_as_root() {
 
 build_as_run_user() {
     install_repo_eval container-sirepo-base
-    install_url radiasoft/sirepo
-    #POSIT: This relies on the fact that individual package names don't have spaces or special chars
-    npm install -g \
-        $(install_download package.json | jq -r '.devDependencies | to_entries | map("\(.key)@\(.value)") | .[]')
 }

--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -12,5 +12,5 @@ build_as_root() {
 }
 
 build_as_run_user() {
-    install_repo_eval container-sirepo-base
+    install_repo_eval container-sirepo-base run_user
 }


### PR DESCRIPTION
This reverts commit 1565104a67e49d307463ca6450a6525d8639401f.

I accidentally committed to main so I reverted there and I moved the commit to a PR.

Commit message of original commit (5a95760a97559c7539426ead7360cdc5feaae41a).

beamsim-jupyter provides its own ~/.post_bivio_bashrc which then sources ~/jupyter/bashrc

Also, moved common install steps for sirepo containers to installers/container-sirepo-base to share code between container-sirepo-ci and container-sirepo-devbox.